### PR TITLE
Check sign in status

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
+web: bin/rails server
 js: yarn build --watch
 css: yarn build:css --watch

--- a/app/controllers/admin/users/sessions_controller.rb
+++ b/app/controllers/admin/users/sessions_controller.rb
@@ -32,6 +32,10 @@ module Admin
       def after_sign_in_path_for(_resource)
         admin_dashboard_path
       end
+
+      def after_sign_out_path_for(_resource)
+        admin_dashboard_path
+      end
     end
   end
 end

--- a/app/views/admin/shared/_flash_messages.html.erb
+++ b/app/views/admin/shared/_flash_messages.html.erb
@@ -1,0 +1,8 @@
+<%# TODO: 用 view component 做元件，依照 key 顯示不同樣式的 flash %>
+<div class='w-full justify-center flex p-5'>
+  <% flash.each do |_key, message| %>
+    <div class='text-lg'>  
+      <%= message %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -26,6 +26,7 @@
   <body>
     <div id='admin-body-container' class='mx-auto'>
       <%= render 'admin/shared/header' %>
+      <%= render 'admin/shared/flash_messages' %>
       <div class='w-full justify-center md:flex lg:gap-9 p-5'>
         <%= yield %>
       </div>

--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,6 @@
 #!/usr/bin/env sh
 
-if gem list --no-installed --exact --silent foreman; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
-exec foreman start -f Procfile.dev --env /dev/null "$@"
+exec overmind start - Run procfile

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -278,10 +278,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  require Rails.root.join('lib/devise/strategies/status_authenticatable')
+  config.warden do |manager|
+    manager.intercept_401 = false
+    manager.default_strategies(scope: :admin_user).unshift :status_authenticatable
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/locales/devise.zh-TW.yml
+++ b/config/locales/devise.zh-TW.yml
@@ -14,6 +14,7 @@ zh-TW:
       timeout: "您的登入時效過期，請重新登入。"
       unauthenticated: "您需要先登入或註冊後才能繼續。"
       unconfirmed: "您的信箱尚未驗證，請先驗證。"
+      unauthorized_status: "您的帳號不符合登入權限。"
     mailer:
       confirmation_instructions:
         subject: "帳號驗證步驟"

--- a/lib/devise/strategies/status_authenticatable.rb
+++ b/lib/devise/strategies/status_authenticatable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/authenticatable'
+
+module Devise
+  module Strategies
+    class StatusAuthenticatable < Authenticatable
+      def authenticate!
+        resource = valid_password? && mapping.to.find_for_database_authentication(authentication_hash)
+        return fail!(:invalid) if resource.blank?
+        return fail!(:unauthorized_status) if resource.general_status?
+
+        success!(resource)
+      end
+    end
+  end
+end
+
+Warden::Strategies.add(:status_authenticatable, Devise::Strategies::StatusAuthenticatable)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,4 +16,10 @@ FactoryBot.define do
   trait :female do
     id_card_number { "A2#{n.to_s.rjust(8, '0')}" }
   end
+
+  User::STATUSES.each do |key, value|
+    trait key do
+      status { value }
+    end
+  end
 end

--- a/spec/features/admin/user_authentication_spec.rb
+++ b/spec/features/admin/user_authentication_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin User Signin Authentication', type: :feature do
+  describe 'Sign in with status verification' do
+    User::STATUSES.each_key do |key|
+      context "with #{key} status" do
+        it_behaves_like 'admin signin attempt', key, key != :general
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/authentication_examples.rb
+++ b/spec/support/shared_examples/authentication_examples.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'admin signin attempt' do |status, is_successful|
+  let(:user) { create(:user, status) }
+
+  before do
+    visit new_admin_user_session_path
+    fill_in 'admin_user[id_card_number]', with: user.id_card_number
+    fill_in 'admin_user[password]', with: user.password
+    click_button '登入'
+  end
+
+  if is_successful
+    it 'allows signin and redirects to dashboard' do
+      expect(current_path).to eq(admin_dashboard_path)
+      expect(page).to have_content(I18n.t('devise.sessions.signed_in'))
+    end
+  else
+    it 'prevents signin and shows unauthorized message' do
+      expect(current_path).to eq(new_admin_user_session_path)
+      expect(page).to have_content(I18n.t('devise.failure.unauthorized_status'))
+    end
+  end
+end


### PR DESCRIPTION
## 概述

本次 PR 主要是確認使用者在後台進行登入時， status 為 general 的使用者是不允許登入後台的。

## 主要變更

### 1. 權限控制與認證機制

#### 自定義 Devise 認證策略實現

- 新增 `StatusAuthenticatable` 策略，限制狀態為 `general` 的使用者無法登入管理後台
- 在 Devise 配置中啟用該策略，優先於默認認證策略執行
- 添加相應的本地化錯誤訊息 `unauthorized_status`

#### 登出後路徑設定

- 在 `Admin::Users::SessionsController` 中添加 `after_sign_out_path_for` 方法，使登出後重定向至 admin dashboard

### 2. UI 與使用者體驗改進

#### 閃現訊息顯示元件

- 新增 `_flash_messages.html.erb` 元件，負責顯示系統訊息
- 用註解標記了將來使用 ViewComponent 優化的計劃

### 3. 開發環境與配置優化

#### 開發環境變更

- 移除 Procfile 中的 Ruby debug 選項
- 將開發服務管理工具從 Foreman 切換到 Overmind
- 簡化了 `bin/dev` 腳本，刪除自動安裝 Foreman 的邏輯

### 4. 測試改進

#### Status 驗證測試

- 為 user factory_bot 添加 status trait，支援所有使用者狀態
- 新增管理員登入驗證測試，確保僅適當狀態 ( 非 general ) 的使用者可以登入
- 以 `User::STATUSES` 實作 trait 與 feature test，以免 STATUSES 增減而遺漏相關修改，讓修改能一同調整。


